### PR TITLE
Inf ll bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mamba
 Type: Package
 Title: MAMBA: Meta-analysis Model Based Assessment of Replicability 
-Version: 1.12
+Version: 1.13
 Date: 2018-08-04
 Author: Dan McGuire 
 Maintainer: Dan McGuire <dmcguire2@pennstatehealth.psu.edu>

--- a/R/source1.R
+++ b/R/source1.R
@@ -476,7 +476,7 @@ mamba<-function(betajk, sjk2,
     
     gammaj<-unlist(mclapply(1:MM, function(j){
       gam<- p*exp(llbR1[j])/(exp(mamba:::logsumexp(c(log(p) + llbR1[j], log(1-p) + llbR0[j]))))
-      if(is.na(gam)){
+      if(is.na(gam) | is.infinite(gam)){
         m<-which.max(c(log(1-p) + llbR0[j],
                        log(p) + llbR1[j]))                      
         gam<-(m-1)


### PR DESCRIPTION
encountered case where log likelihood was infinite for a single snp, causing model fitting to fail.  This fixes the issue.